### PR TITLE
unpack and handle NLMSG_ERROR response sent by kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,6 @@ dependencies = [
  "log",
  "mimalloc",
  "mini-moka",
- "mnl",
  "mnl-sys",
  "nftnl-sys",
  "pretty_env_logger",
@@ -661,17 +660,6 @@ dependencies = [
  "smallvec",
  "tagptr",
  "triomphe",
-]
-
-[[package]]
-name = "mnl"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d3a616a69f9e3b7c5c3c9f707fe146bea1d2eef93b706271a9bc3f1070f71fb"
-dependencies = [
- "libc",
- "log",
- "mnl-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ humantime = "2.1.0"
 rustc-hash = "1.1.0"
 mimalloc = "0.1.39"
 nftnl-sys = "0.6.4"
-mnl-sys = "0.2.2"
+mnl-sys = { version = "0.2.2", features = ["mnl-1-0-4"] }
 libc = "0.2.178"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ mimalloc = "0.1.39"
 nftnl-sys = "0.6.4"
 mnl-sys = "0.2.2"
 libc = "0.2.178"
-mnl = "0.3.0"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -34,7 +34,9 @@ fn dry_run(c: &mut Criterion) {
     group.bench_function("single_ipv4", |b| {
         let mut leroy = make_leroy();
         b.iter(|| {
-            leroy.handle_line(&black_box(b"142.250.185.142".to_vec()));
+            leroy
+                .handle_line(&black_box(b"142.250.185.142".to_vec()))
+                .unwrap();
         })
     });
 
@@ -42,7 +44,9 @@ fn dry_run(c: &mut Criterion) {
     group.bench_function("single_ipv6", |b| {
         let mut leroy = make_leroy();
         b.iter(|| {
-            leroy.handle_line(&black_box(b"2a00:1450:4001:813::200e".to_vec()));
+            leroy
+                .handle_line(&black_box(b"2a00:1450:4001:813::200e".to_vec()))
+                .unwrap();
         })
     });
 
@@ -50,11 +54,21 @@ fn dry_run(c: &mut Criterion) {
     group.bench_function("hammer_few_ips", |b| {
         let mut leroy = make_leroy();
         b.iter(|| {
-            leroy.handle_line(&black_box(b"2001:41d0:307:b200::".to_vec()));
-            leroy.handle_line(&black_box(b"54.38.164.114".to_vec()));
-            leroy.handle_line(&black_box(b"152.228.187.173".to_vec()));
-            leroy.handle_line(&black_box(b"54.38.164.114".to_vec()));
-            leroy.handle_line(&black_box(b"54.38.164.114".to_vec()));
+            leroy
+                .handle_line(&black_box(b"2001:41d0:307:b200::".to_vec()))
+                .unwrap();
+            leroy
+                .handle_line(&black_box(b"54.38.164.114".to_vec()))
+                .unwrap();
+            leroy
+                .handle_line(&black_box(b"152.228.187.173".to_vec()))
+                .unwrap();
+            leroy
+                .handle_line(&black_box(b"54.38.164.114".to_vec()))
+                .unwrap();
+            leroy
+                .handle_line(&black_box(b"54.38.164.114".to_vec()))
+                .unwrap();
         })
     });
 
@@ -63,7 +77,9 @@ fn dry_run(c: &mut Criterion) {
         let mut leroy = make_leroy();
         let mut bits = 0;
         b.iter(|| {
-            leroy.handle_line(&black_box(Ipv4Addr::from(bits).to_string().into_bytes()));
+            leroy
+                .handle_line(&black_box(Ipv4Addr::from(bits).to_string().into_bytes()))
+                .unwrap();
             bits += 3733;
         })
     });
@@ -74,11 +90,17 @@ fn dry_run(c: &mut Criterion) {
         let mut bits = 0;
         b.iter(|| {
             for _ in 0..20 {
-                leroy.handle_line(&black_box(Ipv4Addr::from(bits).to_string().into_bytes()));
-                leroy.handle_line(&black_box(Ipv4Addr::from(!bits).to_string().into_bytes()));
-                leroy.handle_line(&black_box(
-                    Ipv4Addr::from(bits.swap_bytes()).to_string().into_bytes(),
-                ));
+                leroy
+                    .handle_line(&black_box(Ipv4Addr::from(bits).to_string().into_bytes()))
+                    .unwrap();
+                leroy
+                    .handle_line(&black_box(Ipv4Addr::from(!bits).to_string().into_bytes()))
+                    .unwrap();
+                leroy
+                    .handle_line(&black_box(
+                        Ipv4Addr::from(bits.swap_bytes()).to_string().into_bytes(),
+                    ))
+                    .unwrap();
             }
             bits += 3733;
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
     error::Error,
     ffi::CString,
     hash::BuildHasherDefault,
-    io,
+    io, mem,
     net::{IpAddr, Ipv4Addr, Ipv6Addr},
     num::NonZeroU32,
     time::{Duration, Instant},
@@ -261,31 +261,30 @@ impl Leroy {
             let bytes = self.nlmsg_batch.as_bytes();
             socket.send(bytes)?;
 
-            let mut recoverable_error = false;
+            let mut seen_enfile = false;
             let port_id = socket.port_id();
             while let Err(err) =
                 socket.recv_and_validate(&mut self.nlmsg_recv_buffer, Some(seq), port_id)
             {
                 match err.raw_os_error() {
-                    Some(libc::EAGAIN) if recoverable_error => break, // All errors drained
+                    Some(libc::EAGAIN) if seen_enfile => return Ok(()), // All errors drained
                     Some(libc::ENFILE) => {
-                        error!("Error ENFILE banning {ip}: Set full?");
-                        recoverable_error = true;
+                        // Recoverable. Continue looking for other errors.
+                        // Usually sent twice (once for each NFT_MSG_NEWSETELEM) above.
+                        if !mem::replace(&mut seen_enfile, true) {
+                            error!("Error ENFILE banning {ip}: Set full?");
+                        }
                     }
                     Some(libc::ENOENT) => {
                         error!("Error ENOENT banning {ip}: Table or set not created yet?");
-                        recoverable_error = true;
+                        return Err(err);
                     }
                     Some(libc::EPERM) => {
                         error!("Error EPERM banning {ip}: Permission denied");
-                        return Err(err); // Unrecoverable
+                        return Err(err);
                     }
-                    _ => return Err(err), // Unknown, likely unrecoverable
+                    _ => return Err(err),
                 }
-            }
-
-            if recoverable_error {
-                return Ok(());
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,9 @@ use std::{
 
 use clap::Parser;
 use governor::Quota;
-use libc::{NFPROTO_INET, NFT_MSG_DELSETELEM, NFT_MSG_NEWSETELEM, NLM_F_CREATE, NLM_F_REQUEST};
+use libc::{
+    NFPROTO_INET, NFT_MSG_DELSETELEM, NFT_MSG_NEWSETELEM, NLM_F_ACK, NLM_F_CREATE, NLM_F_REQUEST,
+};
 use log::{debug, error, info};
 use mini_moka::unsync::Cache;
 use mnl_sys::MNL_SOCKET_BUFFER_SIZE;
@@ -168,7 +170,7 @@ impl Leroy {
         Ok(leroy)
     }
 
-    pub fn handle_line(&mut self, line: &Vec<u8>) {
+    pub fn handle_line(&mut self, line: &Vec<u8>) -> io::Result<()> {
         self.line_count += 1;
 
         if self
@@ -177,7 +179,7 @@ impl Leroy {
             .is_none_or(|l| l.check_key(line).is_err())
         {
             match IpAddr::parse_ascii(line) {
-                Ok(ip) => self.ban(ip).expect("ban"), // Error likely unrecoverable
+                Ok(ip) => self.ban(ip)?,
                 Err(err) => error!(
                     "Error parsing IP from {:?}: {}",
                     String::from_utf8_lossy(line),
@@ -197,6 +199,8 @@ impl Leroy {
             self.line_count = 0;
             self.line_count_start = Instant::now();
         }
+
+        Ok(())
     }
 
     fn ban(&mut self, ip: IpAddr) -> io::Result<()> {
@@ -207,6 +211,10 @@ impl Leroy {
 
         let recidivism: u32 = *self.recidivism_counts.get(&ip).unwrap_or(&0) + 1;
         let timeout = self.args.time_to_ban(recidivism);
+        info!(
+            "Banning {ip} for {}s (recidivism: {recidivism})",
+            timeout.as_secs()
+        );
 
         let mut set = NftnlSet::new();
         set.set_table(&self.args.table);
@@ -243,53 +251,52 @@ impl Leroy {
         self.nlmsg_batch.set_elems(
             NFT_MSG_NEWSETELEM as u16,
             NFPROTO_INET as u16,
-            (NLM_F_CREATE | NLM_F_REQUEST) as u16,
+            (NLM_F_CREATE | NLM_F_REQUEST | NLM_F_ACK) as u16,
             &set,
             seq,
         );
         self.nlmsg_batch.end(seq);
 
-        let response = if let Some(socket) = &mut self.socket {
-            // Send.
+        if let Some(socket) = &mut self.socket {
             let bytes = self.nlmsg_batch.as_bytes();
             socket.send(bytes)?;
 
-            // Receive (NLM_F_ACK on batch end, exactly one response per batch).
+            let mut seen_error = false;
             let port_id = socket.port_id();
-            let res = socket.recv_and_validate(&mut self.nlmsg_recv_buffer[..], Some(seq), port_id);
-            if res.is_err() {
-                socket.recv_and_validate(&mut self.nlmsg_recv_buffer[..], Some(seq), port_id);
-            }
-            res
-        } else {
-            Ok(0)
-        };
-
-        match response {
-            Ok(_) => {
-                info!(
-                    "Banned {ip} for {}s (recidivism: {recidivism})",
-                    timeout.as_secs()
-                );
-
-                self.ban_cache.insert(ip, ());
-                self.recidivism_counts.insert(ip, recidivism);
-
-                self.ban_count += 1;
-                if self.ban_count_start.elapsed() > self.args.reporting_ban_time_period {
-                    info!(
-                        "Banned {} ips in the past {}s",
-                        self.ban_count,
-                        self.ban_count_start.elapsed().as_secs()
-                    );
-                    self.ban_count = 0;
-                    self.ban_count_start = Instant::now();
+            while let Err(err) =
+                socket.recv_and_validate(&mut self.nlmsg_recv_buffer[..], Some(seq), port_id)
+            {
+                match err {
+                    err if seen_error && err.kind() == io::ErrorKind::WouldBlock => break,
+                    err if err.raw_os_error() == Some(libc::ENFILE) => {
+                        error!("Error ENFILE banning {ip}: Set full?");
+                        seen_error = true;
+                    }
+                    err if err.raw_os_error() == Some(libc::ENOENT) => {
+                        error!("Error ENOENT banning {ip}: Table or set not created yet?");
+                        seen_error = true;
+                    }
+                    err if err.raw_os_error() == Some(libc::EPERM) => {
+                        error!("Error EPERM banning {ip}: Permission denied");
+                        return Err(err); // Unrecoverable
+                    }
+                    err => return Err(err), // Unknown, likely unrecoverable
                 }
             }
-            Err(err) if err.raw_os_error() == Some(libc::ENFILE) => {
-                error!("Failed to ban {ip}: ENFILE (set full?)");
-            }
-            Err(err) => return Err(err),
+        }
+
+        self.ban_cache.insert(ip, ());
+        self.recidivism_counts.insert(ip, recidivism);
+
+        self.ban_count += 1;
+        if self.ban_count_start.elapsed() > self.args.reporting_ban_time_period {
+            info!(
+                "Banned {} ips in the past {}s",
+                self.ban_count,
+                self.ban_count_start.elapsed().as_secs()
+            );
+            self.ban_count = 0;
+            self.ban_count_start = Instant::now();
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,7 @@ use std::{
 
 use clap::Parser;
 use governor::Quota;
-use libc::{
-    NFPROTO_INET, NFT_MSG_DELSETELEM, NFT_MSG_NEWSETELEM, NLM_F_ACK, NLM_F_CREATE, NLM_F_REQUEST,
-};
+use libc::{NFPROTO_INET, NFT_MSG_DELSETELEM, NFT_MSG_NEWSETELEM, NLM_F_CREATE, NLM_F_REQUEST};
 use log::{debug, error, info};
 use mini_moka::unsync::Cache;
 use mnl_sys::MNL_SOCKET_BUFFER_SIZE;
@@ -133,7 +131,7 @@ impl Leroy {
             socket: (!args.dry_run).then(MnlSocket::new_netfilter).transpose()?,
             seq_generator: SeqGenerator::new(),
             nlmsg_batch: NlmsgBatch::new(),
-            nlmsg_recv_buffer: vec![0; MNL_SOCKET_BUFFER_SIZE() as usize * 2],
+            nlmsg_recv_buffer: vec![0; MNL_SOCKET_BUFFER_SIZE() as usize],
             ip_rate_limiters: match NonZeroU32::new(args.bl_threshold) {
                 Some(bl_threshold) => Some(KeyedLimiter::new(
                     Quota::with_period(args.bl_period)
@@ -210,11 +208,6 @@ impl Leroy {
         let recidivism: u32 = *self.recidivism_counts.get(&ip).unwrap_or(&0) + 1;
         let timeout = self.args.time_to_ban(recidivism);
 
-        info!(
-            "Banning {ip} for {}s (recidivism: {recidivism})",
-            timeout.as_secs()
-        );
-
         let mut set = NftnlSet::new();
         set.set_table(&self.args.table);
         set.set_name(match ip {
@@ -250,42 +243,53 @@ impl Leroy {
         self.nlmsg_batch.set_elems(
             NFT_MSG_NEWSETELEM as u16,
             NFPROTO_INET as u16,
-            (NLM_F_CREATE | NLM_F_REQUEST | NLM_F_ACK) as u16,
+            (NLM_F_CREATE | NLM_F_REQUEST) as u16,
             &set,
             seq,
         );
         self.nlmsg_batch.end(seq);
 
-        if let Some(socket) = &mut self.socket {
+        let response = if let Some(socket) = &mut self.socket {
+            // Send.
             let bytes = self.nlmsg_batch.as_bytes();
             socket.send(bytes)?;
-            loop {
-                match socket.recv_and_validate(
-                    &mut self.nlmsg_recv_buffer[..],
-                    None, // Some(seq),
-                    socket.port_id(),
-                ) {
-                    Ok(_) => break,
-                    Err(err) if err.raw_os_error() == Some(libc::ENFILE) => {
-                        error!("Failed to ban {ip}: ENFILE (set full?)");
-                    }
-                    Err(err) => return Err(err),
+
+            // Receive (NLM_F_ACK on batch end, exactly one response per batch).
+            let port_id = socket.port_id();
+            let res = socket.recv_and_validate(&mut self.nlmsg_recv_buffer[..], Some(seq), port_id);
+            if res.is_err() {
+                socket.recv_and_validate(&mut self.nlmsg_recv_buffer[..], Some(seq), port_id);
+            }
+            res
+        } else {
+            Ok(0)
+        };
+
+        match response {
+            Ok(_) => {
+                info!(
+                    "Banned {ip} for {}s (recidivism: {recidivism})",
+                    timeout.as_secs()
+                );
+
+                self.ban_cache.insert(ip, ());
+                self.recidivism_counts.insert(ip, recidivism);
+
+                self.ban_count += 1;
+                if self.ban_count_start.elapsed() > self.args.reporting_ban_time_period {
+                    info!(
+                        "Banned {} ips in the past {}s",
+                        self.ban_count,
+                        self.ban_count_start.elapsed().as_secs()
+                    );
+                    self.ban_count = 0;
+                    self.ban_count_start = Instant::now();
                 }
             }
-        }
-
-        self.ban_cache.insert(ip, ());
-        self.recidivism_counts.insert(ip, recidivism);
-
-        self.ban_count += 1;
-        if self.ban_count_start.elapsed() > self.args.reporting_ban_time_period {
-            info!(
-                "Banned {} ips in the past {}s",
-                self.ban_count,
-                self.ban_count_start.elapsed().as_secs()
-            );
-            self.ban_count = 0;
-            self.ban_count_start = Instant::now();
+            Err(err) if err.raw_os_error() == Some(libc::ENFILE) => {
+                error!("Failed to ban {ip}: ENFILE (set full?)");
+            }
+            Err(err) => return Err(err),
         }
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(ip_as_octets)]
 
 mod keyed_limiter;
+mod mnl;
 mod nftnl;
 
 use std::{
@@ -26,6 +27,7 @@ use rustc_hash::FxHasher;
 
 use crate::{
     keyed_limiter::KeyedLimiter,
+    mnl::MnlSocket,
     nftnl::{NftnlSet, NftnlSetElem, NlmsgBatch, Seq},
 };
 
@@ -105,7 +107,7 @@ fn parse_duration(s: &str) -> Result<Duration, humantime::DurationError> {
 }
 
 pub struct Leroy {
-    socket: Option<mnl::Socket>,
+    socket: Option<MnlSocket>,
     nlmsg_batch: NlmsgBatch,
     nlmsg_recv_buffer: Vec<u8>,
 
@@ -125,9 +127,7 @@ pub struct Leroy {
 impl Leroy {
     pub fn new(args: Args) -> Result<Leroy, Box<dyn Error>> {
         let mut leroy = Leroy {
-            socket: (!args.dry_run)
-                .then(|| mnl::Socket::new(mnl::Bus::Netfilter))
-                .transpose()?,
+            socket: (!args.dry_run).then(MnlSocket::new_netfilter).transpose()?,
             nlmsg_batch: NlmsgBatch::new(Seq(0)),
             nlmsg_recv_buffer: vec![0; MNL_SOCKET_BUFFER_SIZE() as usize],
             ip_rate_limiters: match NonZeroU32::new(args.bl_threshold) {
@@ -246,15 +246,8 @@ impl Leroy {
 
         if let Some(socket) = &mut self.socket {
             let bytes = self.nlmsg_batch.as_bytes();
-            let tx = socket.send(bytes)?;
-            if tx != bytes.len() {
-                return Err(io::Error::other("did not send entire batch"));
-            }
-
-            for response in socket.recv(&mut self.nlmsg_recv_buffer[..])? {
-                let response = response?;
-                mnl::cb_run(response, seq.0, socket.portid())?;
-            }
+            socket.send(bytes)?;
+            socket.recv_and_validate(&mut self.nlmsg_recv_buffer[..], seq, socket.port_id())?;
         }
 
         info!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,7 @@ impl Leroy {
                         warn!("Error ENOENT banning {ip}: Ignoring after ENFILE");
                     }
                     Some(libc::ENOENT) => {
-                        error!("Error ENOENT banning {ip}: Table or set not created yet?");
+                        error!("Error ENOENT banning {ip}: Table or set not created?");
                         return Err(err);
                     }
                     Some(libc::EPERM) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@
 mod keyed_limiter;
 mod mnl;
 mod nftnl;
+mod seq;
 
 use std::{
     error::Error,
@@ -24,11 +25,12 @@ use log::{debug, error, info};
 use mini_moka::unsync::Cache;
 use mnl_sys::MNL_SOCKET_BUFFER_SIZE;
 use rustc_hash::FxHasher;
+use seq::SeqGenerator;
 
 use crate::{
     keyed_limiter::KeyedLimiter,
     mnl::MnlSocket,
-    nftnl::{NftnlSet, NftnlSetElem, NlmsgBatch, Seq},
+    nftnl::{NftnlSet, NftnlSetElem, NlmsgBatch},
 };
 
 #[derive(Parser, Debug)]
@@ -108,6 +110,7 @@ fn parse_duration(s: &str) -> Result<Duration, humantime::DurationError> {
 
 pub struct Leroy {
     socket: Option<MnlSocket>,
+    seq_generator: SeqGenerator,
     nlmsg_batch: NlmsgBatch,
     nlmsg_recv_buffer: Vec<u8>,
 
@@ -128,8 +131,9 @@ impl Leroy {
     pub fn new(args: Args) -> Result<Leroy, Box<dyn Error>> {
         let mut leroy = Leroy {
             socket: (!args.dry_run).then(MnlSocket::new_netfilter).transpose()?,
-            nlmsg_batch: NlmsgBatch::new(Seq(0)),
-            nlmsg_recv_buffer: vec![0; MNL_SOCKET_BUFFER_SIZE() as usize],
+            seq_generator: SeqGenerator::new(),
+            nlmsg_batch: NlmsgBatch::new(),
+            nlmsg_recv_buffer: vec![0; MNL_SOCKET_BUFFER_SIZE() as usize * 2],
             ip_rate_limiters: match NonZeroU32::new(args.bl_threshold) {
                 Some(bl_threshold) => Some(KeyedLimiter::new(
                     Quota::with_period(args.bl_period)
@@ -206,6 +210,11 @@ impl Leroy {
         let recidivism: u32 = *self.recidivism_counts.get(&ip).unwrap_or(&0) + 1;
         let timeout = self.args.time_to_ban(recidivism);
 
+        info!(
+            "Banning {ip} for {}s (recidivism: {recidivism})",
+            timeout.as_secs()
+        );
+
         let mut set = NftnlSet::new();
         set.set_table(&self.args.table);
         set.set_name(match ip {
@@ -218,14 +227,16 @@ impl Leroy {
         elem.set_timeout(timeout);
         set.add(elem);
 
+        let seq = self.seq_generator.inc();
         self.nlmsg_batch.reset();
-        self.nlmsg_batch.begin();
+        self.nlmsg_batch.begin(seq);
         // Ensure following delete succeeds unconditionally.
         self.nlmsg_batch.set_elems(
             NFT_MSG_NEWSETELEM as u16,
             NFPROTO_INET as u16,
             (NLM_F_CREATE | NLM_F_REQUEST) as u16,
             &set,
+            seq,
         );
         // Delete to reset timeout if element already exists.
         self.nlmsg_batch.set_elems(
@@ -233,6 +244,7 @@ impl Leroy {
             NFPROTO_INET as u16,
             (NLM_F_CREATE | NLM_F_REQUEST) as u16,
             &set,
+            seq,
         );
         // Add element with new timeout.
         self.nlmsg_batch.set_elems(
@@ -240,20 +252,27 @@ impl Leroy {
             NFPROTO_INET as u16,
             (NLM_F_CREATE | NLM_F_REQUEST | NLM_F_ACK) as u16,
             &set,
+            seq,
         );
-        let seq = self.nlmsg_batch.seq();
-        self.nlmsg_batch.end();
+        self.nlmsg_batch.end(seq);
 
         if let Some(socket) = &mut self.socket {
             let bytes = self.nlmsg_batch.as_bytes();
             socket.send(bytes)?;
-            socket.recv_and_validate(&mut self.nlmsg_recv_buffer[..], seq, socket.port_id())?;
+            loop {
+                match socket.recv_and_validate(
+                    &mut self.nlmsg_recv_buffer[..],
+                    None, // Some(seq),
+                    socket.port_id(),
+                ) {
+                    Ok(_) => break,
+                    Err(err) if err.raw_os_error() == Some(libc::ENFILE) => {
+                        error!("Failed to ban {ip}: ENFILE (set full?)");
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
         }
-
-        info!(
-            "Banning {ip} for {}s (recidivism: {recidivism})",
-            timeout.as_secs()
-        );
 
         self.ban_cache.insert(ip, ());
         self.recidivism_counts.insert(ip, recidivism);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,7 @@ impl Leroy {
                 socket.recv_and_validate(&mut self.nlmsg_recv_buffer, Some(seq), port_id)
             {
                 match err.raw_os_error() {
-                    Some(libc::EAGAIN) if recoverable_error => break, // All errros drained
+                    Some(libc::EAGAIN) if recoverable_error => break, // All errors drained
                     Some(libc::ENFILE) => {
                         error!("Error ENFILE banning {ip}: Set full?");
                         recoverable_error = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ use seq::SeqGenerator;
 
 use crate::{
     keyed_limiter::KeyedLimiter,
-    mnl::MnlSocket,
+    mnl::{MnlReceiveBuffer, MnlSocket},
     nftnl::{NftnlSet, NftnlSetElem, NlmsgBatch},
 };
 
@@ -112,7 +112,7 @@ pub struct Leroy {
     socket: Option<MnlSocket>,
     seq_generator: SeqGenerator,
     nlmsg_batch: NlmsgBatch,
-    nlmsg_recv_buffer: Vec<u8>,
+    nlmsg_recv_buffer: MnlReceiveBuffer,
 
     ip_rate_limiters: Option<KeyedLimiter<Vec<u8>, BuildHasherDefault<FxHasher>>>,
     ban_cache: Cache<IpAddr, (), BuildHasherDefault<FxHasher>>,
@@ -133,7 +133,7 @@ impl Leroy {
             socket: (!args.dry_run).then(MnlSocket::new_netfilter).transpose()?,
             seq_generator: SeqGenerator::new(),
             nlmsg_batch: NlmsgBatch::new(),
-            nlmsg_recv_buffer: vec![0; MNL_SOCKET_BUFFER_SIZE() as usize],
+            nlmsg_recv_buffer: MnlReceiveBuffer::new(MNL_SOCKET_BUFFER_SIZE() as usize),
             ip_rate_limiters: match NonZeroU32::new(args.bl_threshold) {
                 Some(bl_threshold) => Some(KeyedLimiter::new(
                     Quota::with_period(args.bl_period)
@@ -264,7 +264,7 @@ impl Leroy {
             let mut seen_error = false;
             let port_id = socket.port_id();
             while let Err(err) =
-                socket.recv_and_validate(&mut self.nlmsg_recv_buffer[..], Some(seq), port_id)
+                socket.recv_and_validate(&mut self.nlmsg_recv_buffer, Some(seq), port_id)
             {
                 match err {
                     err if seen_error && err.kind() == io::ErrorKind::WouldBlock => break,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,27 +261,31 @@ impl Leroy {
             let bytes = self.nlmsg_batch.as_bytes();
             socket.send(bytes)?;
 
-            let mut seen_error = false;
+            let mut recoverable_error = false;
             let port_id = socket.port_id();
             while let Err(err) =
                 socket.recv_and_validate(&mut self.nlmsg_recv_buffer, Some(seq), port_id)
             {
-                match err {
-                    err if seen_error && err.kind() == io::ErrorKind::WouldBlock => break,
-                    err if err.raw_os_error() == Some(libc::ENFILE) => {
+                match err.raw_os_error() {
+                    Some(libc::EAGAIN) if recoverable_error => break, // All errros drained
+                    Some(libc::ENFILE) => {
                         error!("Error ENFILE banning {ip}: Set full?");
-                        seen_error = true;
+                        recoverable_error = true;
                     }
-                    err if err.raw_os_error() == Some(libc::ENOENT) => {
+                    Some(libc::ENOENT) => {
                         error!("Error ENOENT banning {ip}: Table or set not created yet?");
-                        seen_error = true;
+                        recoverable_error = true;
                     }
-                    err if err.raw_os_error() == Some(libc::EPERM) => {
+                    Some(libc::EPERM) => {
                         error!("Error EPERM banning {ip}: Permission denied");
                         return Err(err); // Unrecoverable
                     }
-                    err => return Err(err), // Unknown, likely unrecoverable
+                    _ => return Err(err), // Unknown, likely unrecoverable
                 }
+            }
+
+            if recoverable_error {
+                return Ok(());
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use governor::Quota;
 use libc::{
     NFPROTO_INET, NFT_MSG_DELSETELEM, NFT_MSG_NEWSETELEM, NLM_F_ACK, NLM_F_CREATE, NLM_F_REQUEST,
 };
-use log::{debug, error, info};
+use log::{debug, error, info, warn};
 use mini_moka::unsync::Cache;
 use mnl_sys::MNL_SOCKET_BUFFER_SIZE;
 use rustc_hash::FxHasher;
@@ -274,6 +274,9 @@ impl Leroy {
                         if !mem::replace(&mut seen_enfile, true) {
                             error!("Error ENFILE banning {ip}: Set full?");
                         }
+                    }
+                    Some(libc::ENOENT) if seen_enfile => {
+                        warn!("Error ENOENT banning {ip}: Ignoring after ENFILE");
                     }
                     Some(libc::ENOENT) => {
                         error!("Error ENOENT banning {ip}: Table or set not created yet?");

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         if line[line.len() - 1] == b'\n' {
             line.pop();
         }
-        leroy.handle_line(&line);
+        leroy.handle_line(&line)?;
         line.clear();
     }
 

--- a/src/mnl.rs
+++ b/src/mnl.rs
@@ -6,7 +6,7 @@ use std::{
 
 use mnl_sys::{
     MNL_SOCKET_AUTOPID, mnl_cb_run, mnl_socket, mnl_socket_bind, mnl_socket_close,
-    mnl_socket_get_portid, mnl_socket_open, mnl_socket_recvfrom, mnl_socket_sendto,
+    mnl_socket_get_portid, mnl_socket_open2, mnl_socket_recvfrom, mnl_socket_sendto,
 };
 
 use crate::seq::Seq;
@@ -23,9 +23,14 @@ impl MnlSocket {
     }
 
     fn open_netfilter() -> io::Result<Self> {
+        // Note: Sending/receiving for netfilter sockets is synchronous
+        // even with SOCK_NONBLOCK. It merely makes mnl_socket_recvfrom() not
+        // block if no further response is available.
         Ok(MnlSocket {
-            inner: NonNull::new(unsafe { mnl_socket_open(libc::NETLINK_NETFILTER) })
-                .ok_or_else(io::Error::last_os_error)?,
+            inner: NonNull::new(unsafe {
+                mnl_socket_open2(libc::NETLINK_NETFILTER, libc::SOCK_NONBLOCK)
+            })
+            .ok_or_else(io::Error::last_os_error)?,
         })
     }
 

--- a/src/mnl.rs
+++ b/src/mnl.rs
@@ -93,7 +93,7 @@ impl MnlSocket {
                 ptr::null_mut(),
             )
         };
-        if ret != 0 {
+        if ret < 0 {
             return Err(io::Error::last_os_error());
         }
         Ok(num_bytes)

--- a/src/mnl.rs
+++ b/src/mnl.rs
@@ -1,0 +1,105 @@
+use std::{
+    ffi::{c_uint, c_void},
+    io,
+    ptr::{self, NonNull},
+};
+
+use mnl_sys::{
+    MNL_SOCKET_AUTOPID, mnl_cb_run, mnl_socket, mnl_socket_bind, mnl_socket_close,
+    mnl_socket_get_portid, mnl_socket_open, mnl_socket_recvfrom, mnl_socket_sendto,
+};
+
+use crate::nftnl::Seq;
+
+pub struct MnlSocket {
+    inner: NonNull<mnl_socket>,
+}
+
+impl MnlSocket {
+    pub fn new_netfilter() -> io::Result<Self> {
+        let mut socket = Self::open_netfilter()?;
+        socket.bind()?;
+        Ok(socket)
+    }
+
+    fn open_netfilter() -> io::Result<Self> {
+        Ok(MnlSocket {
+            inner: NonNull::new(unsafe { mnl_socket_open(libc::NETLINK_NETFILTER) })
+                .ok_or_else(io::Error::last_os_error)?,
+        })
+    }
+
+    fn bind(&mut self) -> io::Result<()> {
+        if unsafe { mnl_socket_bind(self.inner.as_ptr(), 0, MNL_SOCKET_AUTOPID) } == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    pub fn send(&self, data: &[u8]) -> io::Result<()> {
+        let ret = unsafe {
+            dbg!(mnl_socket_sendto(
+                self.inner.as_ptr(),
+                data.as_ptr().cast::<c_void>(),
+                data.len(),
+            ))
+        };
+        if ret == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        if ret as usize != data.len() {
+            return Err(io::Error::other("partial write for mnl_socket_sendto()"));
+        }
+        Ok(())
+    }
+
+    fn recv_raw(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        let ret = unsafe {
+            mnl_socket_recvfrom(
+                self.inner.as_ptr(),
+                buffer.as_mut_ptr().cast::<c_void>(),
+                buffer.len(),
+            )
+        };
+        if ret == -1 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(ret as usize)
+    }
+
+    pub fn recv_and_validate(
+        &mut self,
+        buffer: &mut [u8],
+        seq: Seq,
+        port_id: MnlPortId,
+    ) -> io::Result<usize> {
+        let num_bytes = self.recv_raw(buffer)?;
+        if unsafe {
+            dbg!(mnl_cb_run(
+                buffer.as_ptr().cast::<c_void>(),
+                num_bytes,
+                seq.0,
+                port_id.0,
+                None,
+                ptr::null_mut(),
+            ))
+        } != 0
+        {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(num_bytes)
+    }
+
+    pub fn port_id(&self) -> MnlPortId {
+        MnlPortId(unsafe { mnl_socket_get_portid(self.inner.as_ptr()) })
+    }
+}
+
+impl Drop for MnlSocket {
+    fn drop(&mut self) {
+        unsafe { mnl_socket_close(self.inner.as_ptr()) };
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct MnlPortId(pub c_uint);

--- a/src/mnl.rs
+++ b/src/mnl.rs
@@ -74,6 +74,9 @@ impl MnlSocket {
         seq: Option<Seq>,
         port_id: MnlPortId,
     ) -> io::Result<usize> {
+        // Do recv as part of the safe wrapper, so that libmnl bug
+        // https://rustsec.org/advisories/RUSTSEC-2025-0142.html does not
+        // lead to unsoundness.
         let num_bytes = self.recv_raw(buffer)?;
         let ret = unsafe {
             mnl_cb_run(
@@ -85,7 +88,7 @@ impl MnlSocket {
                 ptr::null_mut(),
             )
         };
-        if dbg!(ret) != 0 {
+        if ret != 0 {
             return Err(io::Error::last_os_error());
         }
         Ok(num_bytes)

--- a/src/mnl.rs
+++ b/src/mnl.rs
@@ -1,6 +1,7 @@
 use std::{
+    alloc,
     ffi::{c_uint, c_void},
-    io,
+    io, mem,
     ptr::{self, NonNull},
 };
 
@@ -58,8 +59,7 @@ impl MnlSocket {
         Ok(())
     }
 
-    fn recv_raw(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
-        // TODO: Check alignment requirements
+    fn recv_raw(&mut self, buffer: &mut MnlReceiveBuffer) -> io::Result<usize> {
         let ret = unsafe {
             mnl_socket_recvfrom(
                 self.inner.as_ptr(),
@@ -75,7 +75,7 @@ impl MnlSocket {
 
     pub fn recv_and_validate(
         &mut self,
-        buffer: &mut [u8],
+        buffer: &mut MnlReceiveBuffer,
         seq: Option<Seq>,
         port_id: MnlPortId,
     ) -> io::Result<usize> {
@@ -112,3 +112,43 @@ impl Drop for MnlSocket {
 
 #[derive(Copy, Clone)]
 pub struct MnlPortId(pub c_uint);
+
+pub struct MnlReceiveBuffer {
+    ptr: *mut u8,
+    layout: alloc::Layout,
+}
+
+impl MnlReceiveBuffer {
+    pub fn new(size: usize) -> Self {
+        let layout = alloc::Layout::from_size_align(
+            size,
+            mem::align_of::<libc::nlmsghdr>(), // NLMSG_ALIGNTO
+        )
+        .expect("valid layout");
+
+        let ptr = unsafe { alloc::alloc(layout) };
+        if ptr.is_null() {
+            alloc::handle_alloc_error(layout);
+        }
+
+        MnlReceiveBuffer { ptr, layout }
+    }
+
+    pub fn as_ptr(&self) -> *const u8 {
+        self.ptr
+    }
+
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.ptr
+    }
+
+    pub fn len(&self) -> usize {
+        self.layout.size()
+    }
+}
+
+impl Drop for MnlReceiveBuffer {
+    fn drop(&mut self) {
+        unsafe { alloc::dealloc(self.ptr, self.layout) };
+    }
+}

--- a/src/mnl.rs
+++ b/src/mnl.rs
@@ -9,7 +9,7 @@ use mnl_sys::{
     mnl_socket_get_portid, mnl_socket_open, mnl_socket_recvfrom, mnl_socket_sendto,
 };
 
-use crate::nftnl::Seq;
+use crate::seq::Seq;
 
 pub struct MnlSocket {
     inner: NonNull<mnl_socket>,
@@ -38,22 +38,23 @@ impl MnlSocket {
 
     pub fn send(&self, data: &[u8]) -> io::Result<()> {
         let ret = unsafe {
-            dbg!(mnl_socket_sendto(
+            mnl_socket_sendto(
                 self.inner.as_ptr(),
                 data.as_ptr().cast::<c_void>(),
                 data.len(),
-            ))
+            )
         };
         if ret == -1 {
             return Err(io::Error::last_os_error());
         }
         if ret as usize != data.len() {
-            return Err(io::Error::other("partial write for mnl_socket_sendto()"));
+            return Err(io::Error::other("partial write for mnl_socket_sendto"));
         }
         Ok(())
     }
 
     fn recv_raw(&mut self, buffer: &mut [u8]) -> io::Result<usize> {
+        // TODO: Check alignment requirements
         let ret = unsafe {
             mnl_socket_recvfrom(
                 self.inner.as_ptr(),
@@ -70,21 +71,21 @@ impl MnlSocket {
     pub fn recv_and_validate(
         &mut self,
         buffer: &mut [u8],
-        seq: Seq,
+        seq: Option<Seq>,
         port_id: MnlPortId,
     ) -> io::Result<usize> {
         let num_bytes = self.recv_raw(buffer)?;
-        if unsafe {
-            dbg!(mnl_cb_run(
+        let ret = unsafe {
+            mnl_cb_run(
                 buffer.as_ptr().cast::<c_void>(),
                 num_bytes,
-                seq.0,
+                seq.map(u32::from).unwrap_or_default(),
                 port_id.0,
                 None,
                 ptr::null_mut(),
-            ))
-        } != 0
-        {
+            )
+        };
+        if dbg!(ret) != 0 {
             return Err(io::Error::last_os_error());
         }
         Ok(num_bytes)

--- a/src/nftnl.rs
+++ b/src/nftnl.rs
@@ -181,10 +181,12 @@ impl NlmsgBatch {
 
     pub fn end(&mut self, seq: Seq) {
         unsafe {
-            nftnl_batch_end(
-                mnl_nlmsg_batch_current(self.batch.as_ptr()).cast::<c_char>(),
-                u32::from(seq),
-            );
+            let ptr = mnl_nlmsg_batch_current(self.batch.as_ptr());
+            nftnl_batch_end(ptr.cast::<c_char>(), u32::from(seq));
+
+            // TODO: Requires kernel 6.10.
+            (*ptr.cast::<libc::nlmsghdr>()).nlmsg_flags |= libc::NLM_F_ACK as u16;
+
             assert!(
                 mnl_nlmsg_batch_next(self.batch.as_ptr()),
                 "mnl_nlmsg_batch_next after end"

--- a/src/nftnl.rs
+++ b/src/nftnl.rs
@@ -19,6 +19,8 @@ use nftnl_sys::{
     nftnl_set_free, nftnl_set_set_str,
 };
 
+use crate::seq::Seq;
+
 pub struct NftnlSet {
     inner: NonNull<nftnl_set>,
 }
@@ -125,24 +127,13 @@ impl Drop for NftnlSetElem {
     }
 }
 
-#[derive(Copy, Clone)]
-pub struct Seq(pub u32);
-
-impl Seq {
-    #[must_use]
-    pub fn inc(self) -> Self {
-        Seq(self.0.wrapping_add(1))
-    }
-}
-
 pub struct NlmsgBatch {
     _buffer: Vec<u8>,
     batch: NonNull<mnl_nlmsg_batch>,
-    seq: Seq,
 }
 
 impl NlmsgBatch {
-    pub fn new(seq: Seq) -> NlmsgBatch {
+    pub fn new() -> NlmsgBatch {
         let mut buffer = vec![0; MNL_SOCKET_BUFFER_SIZE() as usize];
         let batch = NonNull::new(unsafe {
             mnl_nlmsg_batch_start(buffer.as_mut_ptr().cast::<c_void>(), buffer.len())
@@ -152,16 +143,14 @@ impl NlmsgBatch {
         NlmsgBatch {
             _buffer: buffer,
             batch,
-            seq,
         }
     }
 
-    pub fn begin(&mut self) {
-        self.seq = self.seq.inc();
+    pub fn begin(&mut self, seq: Seq) {
         unsafe {
             nftnl_batch_begin(
                 mnl_nlmsg_batch_current(self.batch.as_ptr()).cast::<c_char>(),
-                self.seq.0,
+                u32::from(seq),
             );
             assert!(
                 mnl_nlmsg_batch_next(self.batch.as_ptr()),
@@ -170,15 +159,14 @@ impl NlmsgBatch {
         }
     }
 
-    pub fn set_elems(&mut self, msg_type: u16, family: u16, flags: u16, set: &NftnlSet) {
-        self.seq = self.seq.inc();
+    pub fn set_elems(&mut self, msg_type: u16, family: u16, flags: u16, set: &NftnlSet, seq: Seq) {
         let header = unsafe {
             nftnl_nlmsg_build_hdr(
                 mnl_nlmsg_batch_current(self.batch.as_ptr()).cast::<c_char>(),
                 msg_type,
                 family,
                 flags,
-                self.seq.0,
+                u32::from(seq),
             )
         };
 
@@ -191,12 +179,11 @@ impl NlmsgBatch {
         }
     }
 
-    pub fn end(&mut self) {
-        self.seq = self.seq.inc();
+    pub fn end(&mut self, seq: Seq) {
         unsafe {
             nftnl_batch_end(
                 mnl_nlmsg_batch_current(self.batch.as_ptr()).cast::<c_char>(),
-                self.seq.0,
+                u32::from(seq),
             );
             assert!(
                 mnl_nlmsg_batch_next(self.batch.as_ptr()),
@@ -218,10 +205,6 @@ impl NlmsgBatch {
                 mnl_nlmsg_batch_size(self.batch.as_ptr()),
             )
         }
-    }
-
-    pub fn seq(&self) -> Seq {
-        self.seq
     }
 }
 

--- a/src/nftnl.rs
+++ b/src/nftnl.rs
@@ -181,12 +181,10 @@ impl NlmsgBatch {
 
     pub fn end(&mut self, seq: Seq) {
         unsafe {
-            let ptr = mnl_nlmsg_batch_current(self.batch.as_ptr());
-            nftnl_batch_end(ptr.cast::<c_char>(), u32::from(seq));
-
-            // TODO: Requires kernel 6.10.
-            (*ptr.cast::<libc::nlmsghdr>()).nlmsg_flags |= libc::NLM_F_ACK as u16;
-
+            nftnl_batch_end(
+                mnl_nlmsg_batch_current(self.batch.as_ptr()).cast::<c_char>(),
+                u32::from(seq),
+            );
             assert!(
                 mnl_nlmsg_batch_next(self.batch.as_ptr()),
                 "mnl_nlmsg_batch_next after end"

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -1,0 +1,30 @@
+use std::num::{NonZeroU32, Wrapping};
+
+#[derive(Default)]
+pub struct SeqGenerator {
+    state: Wrapping<u32>,
+}
+
+impl SeqGenerator {
+    pub fn new() -> Self {
+        SeqGenerator { state: Wrapping(1) }
+    }
+
+    #[must_use]
+    pub fn inc(&mut self) -> Seq {
+        let seq = self.state;
+        self.state += 1;
+        Seq(NonZeroU32::new(seq.0)
+            .or_else(|| NonZeroU32::new(0x1234_5678))
+            .expect("non-zero sequence number"))
+    }
+}
+
+#[derive(Copy, Clone)]
+pub struct Seq(pub NonZeroU32);
+
+impl From<Seq> for u32 {
+    fn from(seq: Seq) -> Self {
+        seq.0.get()
+    }
+}

--- a/src/seq.rs
+++ b/src/seq.rs
@@ -1,22 +1,23 @@
 use std::num::{NonZeroU32, Wrapping};
 
-#[derive(Default)]
 pub struct SeqGenerator {
     state: Wrapping<u32>,
 }
 
 impl SeqGenerator {
     pub fn new() -> Self {
-        SeqGenerator { state: Wrapping(1) }
+        SeqGenerator { state: Wrapping(0) }
     }
 
     #[must_use]
     pub fn inc(&mut self) -> Seq {
-        let seq = self.state;
         self.state += 1;
-        Seq(NonZeroU32::new(seq.0)
-            .or_else(|| NonZeroU32::new(0x1234_5678))
-            .expect("non-zero sequence number"))
+        if let Some(seq) = NonZeroU32::new(self.state.0) {
+            Seq(seq)
+        } else {
+            self.state += 1;
+            Seq(NonZeroU32::new(self.state.0).expect("non-zero sequence number"))
+        }
     }
 }
 


### PR DESCRIPTION
new behavior:

* set full? log error and continue (but ip doesn't get banned)
* set or table does not exist? log hint and exit with error
* permission denied? log hint and exit with error
* other unknown error? exit with error

to implement this, replace `mnl` crate with custom wrapper around `mnl-sys` for more control. use the same sequence number for all messages in a batch, so that `mnl_cb_run()` unpacks unexpected `NLMSG_ERROR` responses instead of reporting unexpected sequence numbers as general protocol errors.